### PR TITLE
Add apple-mobile-web-app-capable header

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 <title>HackerWeb</title>
 <meta name="apple-mobile-web-app-title" content="HackerWeb">
+<meta name="apple-mobile-web-app-capable" content="yes" />
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="mobile-web-app-capable" content="yes">
 <link rel="shortcut icon" href="icons/favicon.ico">


### PR DESCRIPTION
Adds the `apple-mobile-web-app-capable` header, so that when launched from a homescreen icon it doesn't show the Safari chrome.

You might also want to add a splash screen, it has to be 320x460 then add this:

```
<link rel="apple-touch-startup-image" href="/startup.png">
```
