### PR TITLE
No need webkit-text-size-adjust:none for web theme

### DIFF
--- a/css/hn-web.css
+++ b/css/hn-web.css
@@ -6,7 +6,6 @@ body{
 	background-color: #fff;
 	position: relative;
 	word-wrap: break-word;
-	-webkit-text-size-adjust: none;
 	-ms-text-size-adjust: none;
 	overflow-y: scroll;
 }


### PR DESCRIPTION
Due to Webkit bug [#56543](https://bugs.webkit.org/show_bug.cgi?id=56543), setting "-webkit-text-size-adjust:none" would cause unable to adjust Web page size while zoom in/out on WebKit-based desktop and tablet browsers.
