### PR TITLE
Open HN links inside the app instead of redirecting to news.ycombinator....

### DIFF
--- a/js/hn.js
+++ b/js/hn.js
@@ -328,7 +328,6 @@
 						}
 					}
 
-
 					// 20K chars will be the max to trigger collapsible comments.
 					// I can use number of comments as the condition but some comments
 					// might have too many chars and make the page longer.


### PR DESCRIPTION
I noticed that links to other HN articles always opened outside the webapp, which kind of spoiled the usability for me, so I changed it to open them inside the webapp (same window).

It uses a regular expression to match and get the article ID, and then replaces the href in the link.
