### PR TITLE
Added "apple-" prefix to "-mobile-web-app-capable meta tag"

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 <title>HackerWeb</title>
 <meta name="apple-mobile-web-app-title" content="HackerWeb">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-capable" content="yes">
 <link rel="shortcut icon" href="icons/favicon.ico">
 <link rel="shortcut icon" sizes="196x196" href="icons/favicon-196.png">
 <link rel="shortcut icon" sizes="128x128" href="icons/favicon-128.png">


### PR DESCRIPTION
Added "apple-" prefix to "-mobile-web-app-capable meta tag" as it was missing. See https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html for valid tags.