### PR TITLE
added apple mobile web app capable meta tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
 <meta name="apple-mobile-web-app-title" content="HackerWeb">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black">
 <link rel="shortcut icon" href="icons/favicon.ico">
 <link rel="shortcut icon" sizes="196x196" href="icons/favicon-196.png">
 <link rel="shortcut icon" sizes="128x128" href="icons/favicon-128.png">


### PR DESCRIPTION
Not sure if reasoning for only using the chrome meta tag for mobile web app capable but I added the apple version too so my iOS8 iPhone and iPad will understand that it can be rendered as a native web app when added to the home screen. I understand if this was left out because of the refresh issue when opening a external link and comping back to native web app but for how I use it, it works fine. If this is merged in, I will delete my repository, otherwise, I will keep it in sync so I can use it in native web app mode for myself. Love the app and how clean it is, cheers.