### PR TITLE
[Work in Progress] Add Open Graph metadata tags to HackerWeb

### DIFF
--- a/assets/js/hw.js
+++ b/assets/js/hw.js
@@ -5,6 +5,10 @@
 		return d.getElementById(id);
 	};
 
+	var toArray = function(nodeList){
+		return Array.prototype.slice.call(nodeList)
+	} 
+
 	var pubsubCache = {},
 		clone = function(obj){
 			var target = {};
@@ -49,6 +53,38 @@
 				}
 			}
 			document.title = title;
+		},
+		setOpenGraph: function(data){
+
+			var retrieveMetaTag = function(attribute, value){
+				var meta = toArray(document.getElementsByTagName('meta')).filter(
+					function(m){
+						return m.getAttribute(attribute) === value;
+					})[0];
+				if (meta === undefined) {
+					meta = document.createElement('meta');
+					meta.setAttribute(attribute, value);
+					document.getElementsByTagName('head')[0].appendChild(meta);
+				}
+				return meta;
+			}
+
+			var description = retrieveMetaTag('name', 'description');
+			var descriptionContent = (data === undefined ? 
+				'HackerWeb - a simply readable Hacker News app' : 
+				'Find out what Hacker News thinks of this with HackerWeb.');
+			description.setAttribute('content', descriptionContent);
+			
+			var ogData = [
+				['og:title', data !== undefined ? data.title : 'HackerWeb'],
+				['og:description', descriptionContent],
+				['og:image', data !== undefined ? 'My image lives here' : 'The standard image'],
+			]
+			ogData.forEach(function(ogd) {
+				var meta = retrieveMetaTag('property', ogd[0]);				
+				meta.setAttribute('content',  ogd[1]);
+			})
+
 		}
 	};
 
@@ -270,6 +306,7 @@
 				data.has_post = !!data.title;
 				if (!data.has_post){
 					hw.setTitle();
+					hw.setOpenGraph();
 					$commentsHeading.innerHTML = '';
 					$commentsSection.innerHTML = tmpl1.render(data);
 					hw.pub('adjustCommentsSection');
@@ -307,6 +344,7 @@
 				data.short_hn_url = 'news.ycombinator.com/item?id=' + id;
 				data.hn_url = '//' + data.short_hn_url;
 				hw.setTitle(data.title);
+				hw.setOpenGraph(data);
 				$commentsHeading.innerHTML = data.title;
 
 				var html = tmpl1.render(data, {comments_list: tmpl2});


### PR DESCRIPTION
Had a little hack this morning to try and add Open Graph tags to HackerWeb so that you would get rich previews when sharing hackerweb links with others (I often like to share the HW link rather than the original because HW is just such a cleaner experience to follow the comments!)

More on Open Graph: http://ogp.me/

Some guidance on integration: https://medium.com/@richardoosterhof/how-to-optimize-your-site-for-rich-previews-527ed13a6d69

This definitely isn't working correctly yet, but the gist is here. Not clear if I'll have time to finish refining this so instead of letting it bit rot I figured I'd at least show you what I have and see what you think.

Few thoughts:

1. Do you get any kind of image URL from the HN API? If not we could just use a standard HW app image, or none at all.
2. Likewise do you get a description from the API? I roughly propose here a generic statement, so that with the title a user seeing a rich link sees something like 'Find out what Hacker News thinks of this with HackerWeb.'

Any thoughts appreciated! And great work on HW BTW, use it every day and love it.